### PR TITLE
Fix software's name in the GPL.

### DIFF
--- a/bin/grandpa
+++ b/bin/grandpa
@@ -4,12 +4,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/chaser.py
+++ b/grandpa/chaser.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/chasers/__init__.py
+++ b/grandpa/chasers/__init__.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/chasers/color.py
+++ b/grandpa/chasers/color.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/chasers/fade.py
+++ b/grandpa/chasers/fade.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/chasers/shutter.py
+++ b/grandpa/chasers/shutter.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/color.py
+++ b/grandpa/color.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/controller.py
+++ b/grandpa/controller.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/dmx.py
+++ b/grandpa/dmx.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/fixture.py
+++ b/grandpa/fixture.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/inputdev/console/keys.py
+++ b/grandpa/inputdev/console/keys.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/inputdev/console/mouse.pyx
+++ b/grandpa/inputdev/console/mouse.pyx
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/inputdev/console/rawkbd.py
+++ b/grandpa/inputdev/console/rawkbd.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/clock.py
+++ b/grandpa/interface/ncurses/clock.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/fader.py
+++ b/grandpa/interface/ncurses/fader.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/fb.pyx
+++ b/grandpa/interface/ncurses/fb.pyx
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/fixture.py
+++ b/grandpa/interface/ncurses/fixture.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/main.py
+++ b/grandpa/interface/ncurses/main.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/menu.py
+++ b/grandpa/interface/ncurses/menu.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/root.py
+++ b/grandpa/interface/ncurses/root.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/status.py
+++ b/grandpa/interface/ncurses/status.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/style.py
+++ b/grandpa/interface/ncurses/style.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/ncurses/tavern.py
+++ b/grandpa/interface/ncurses/tavern.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/pyglet/bar.py
+++ b/grandpa/interface/pyglet/bar.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/pyglet/keys.py
+++ b/grandpa/interface/pyglet/keys.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/pyglet/main.py
+++ b/grandpa/interface/pyglet/main.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/interface/pyglet/root.py
+++ b/grandpa/interface/pyglet/root.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/locking.py
+++ b/grandpa/locking.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/main.py
+++ b/grandpa/main.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/grandpa/stage.py
+++ b/grandpa/stage.py
@@ -2,12 +2,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@
 #
 # Copyright (c) 2010 aszlig <"^[0-9]+$"@regexmail.net>
 #
-# LastWatch is free software: you can redistribute it and/or modify
+# GrandPA is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# LastWatch is distributed in the hope that it will be useful,
+# GrandPA is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.


### PR DESCRIPTION
Sorry, discard the previous pull request since I saw only later that all of the GPL marked files had LastWatch in them.
